### PR TITLE
Add claim removal and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# RTCO Super Admin Bot
+
+This project provides a small admin dashboard and Discord bot for managing sellers and trading cards. Data is persisted to local JSON files and served through an Express API.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Create a `.env` file with your Discord credentials. The following variables are used:
+   - `DISCORD_TOKEN`
+   - `CLIENT_ID`
+   - `GUILD_ID`
+   - `DISCORD_POSTING_CHANNEL_ID`
+   - `DISCORD_TRACKING_CHANNEL_ID`
+   - `DISCORD_SHARED_IMAGE_DUMP_CHANNEL_ID`
+   - `JWT_SECRET`
+
+3. Start the server:
+   ```bash
+   npm start
+   ```
+
+The application will launch the Express dashboard and the Discord bot.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ This project provides a small admin dashboard and Discord bot for managing selle
    ```
 
 The application will launch the Express dashboard and the Discord bot.
+
+## Additional Bot Commands
+
+- `!postcategory <Category> [Channel_ID]` – post or update a category embed with refresh/explore buttons

--- a/claimManager.js
+++ b/claimManager.js
@@ -28,4 +28,16 @@ module.exports = {
         await saveClaims(claims);
         return newClaim;
     },
-};
+    // Function to remove a claim based on user and card
+    removeClaim: async (userId, cardId) => {
+        const claims = await getClaims();
+        const index = claims.findIndex(
+            c => c.userId === userId && c.cardId === cardId
+        );
+        if (index === -1) {
+            throw new Error('Claim not found.');
+        }
+        claims.splice(index, 1);
+        await saveClaims(claims);
+        return true;
+    },};


### PR DESCRIPTION
## Summary
- implement `removeClaim` to reverse card claims
- provide a simple README with setup instructions

## Testing
- `npm install`
- `node - <<'NODE'
const cm = require('./claimManager');
(async () => {
  await cm.addClaim({userId:'u1', username:'user', cardId:'c1', cardName:'Card1'});
  await cm.removeClaim('u1','c1');
  console.log('claim count after remove:', (await cm.getClaims()).length);
})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_686dc1b074e083288e334bbe9272984d