### PR TITLE
Add debug logger and improve server error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# RTCO Super Admin Bot
+
+This project provides a small admin dashboard and Discord bot for managing sellers and trading cards. Data is persisted to local JSON files and served through an Express API.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Create a `.env` file with your Discord credentials. The following variables are used:
+   - `DISCORD_TOKEN`
+   - `CLIENT_ID`
+   - `GUILD_ID`
+   - `DISCORD_POSTING_CHANNEL_ID`
+   - `DISCORD_TRACKING_CHANNEL_ID`
+   - `DISCORD_SHARED_IMAGE_DUMP_CHANNEL_ID`
+   - `JWT_SECRET`
+
+3. Start the server:
+   ```bash
+   npm start
+   ```
+
+The application will launch the Express dashboard and the Discord bot.
+
+All console output is mirrored to `debug.log` for easier troubleshooting.
+
+## Additional Bot Commands
+
+- `!postcategory <Category> [Channel_ID]` – post or update a category embed with refresh/explore buttons

--- a/claimManager.js
+++ b/claimManager.js
@@ -28,4 +28,16 @@ module.exports = {
         await saveClaims(claims);
         return newClaim;
     },
-};
+    // Function to remove a claim based on user and card
+    removeClaim: async (userId, cardId) => {
+        const claims = await getClaims();
+        const index = claims.findIndex(
+            c => c.userId === userId && c.cardId === cardId
+        );
+        if (index === -1) {
+            throw new Error('Claim not found.');
+        }
+        claims.splice(index, 1);
+        await saveClaims(claims);
+        return true;
+    },};

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+
+const logFile = path.join(__dirname, 'debug.log');
+const stream = fs.createWriteStream(logFile, { flags: 'a' });
+
+function format(args) {
+    return new Date().toISOString() + ' ' + args.map(a => {
+        if (typeof a === 'string') return a;
+        try { return JSON.stringify(a); } catch { return String(a); }
+    }).join(' ') + '\n';
+}
+
+function hookConsole() {
+    ['log', 'info', 'warn', 'error'].forEach(level => {
+        const orig = console[level];
+        console[level] = (...args) => {
+            try { stream.write(format(args)); } catch { /* ignore */ }
+            orig.apply(console, args);
+        };
+    });
+}
+
+function installGlobalHandlers() {
+    process.on('uncaughtException', err => {
+        console.error('Uncaught Exception:', err);
+    });
+    process.on('unhandledRejection', err => {
+        console.error('Unhandled Rejection:', err);
+    });
+}
+
+module.exports = {
+    init: () => {
+        hookConsole();
+        installGlobalHandlers();
+        console.log(`Debug logging to ${logFile}`);
+    }
+};

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const { Server } = require("socket.io");
 const path = require('path');
 const multer = require('multer');
 const fs = require('fs/promises');
+const logger = require('./logger');
 
 // Manager and Bot imports
 const cardManager = require('./cardManager');
@@ -19,6 +20,7 @@ const app = express();
 const server = http.createServer(app);
 const io = new Server(server);
 const PORT = process.env.PORT || 3000;
+logger.init();
 
 // Multer setup for handling file uploads in memory
 const storage = multer.memoryStorage();
@@ -246,6 +248,18 @@ async function startServer() {
         console.error('Could not log in the Discord bot. Please verify your DISCORD_TOKEN.');
         console.error(`Error details: ${error.message}`);
     }
+
+    server.on('error', (err) => {
+        if (err.code === 'EADDRINUSE') {
+            console.error(`Port ${PORT} is in use. Trying a different port...`);
+            server.listen(0, () => {
+                const newPort = server.address().port;
+                console.log(`Super Admin Dashboard live on http://localhost:${newPort}`);
+            });
+        } else {
+            console.error('Server error:', err);
+        }
+    });
 
     server.listen(PORT, () => console.log(`Super Admin Dashboard live on http://localhost:${PORT}`));
 }


### PR DESCRIPTION
## Summary
- hook console output to `debug.log` with new `logger` module
- initialize logger when server starts
- move server error handler before `listen` to avoid unhandled EADDRINUSE
- document debug log file in README

## Testing
- `npm install`
- `node --check bot.js`
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_686dc1b074e083288e334bbe9272984d